### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,14 @@
+name: Integration Tests
+on: [pull_request]
+
+jobs:
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Setup env
+      run: test/integration/setup-env.sh
+    - name: Run tests
+      run: test/integration/run.sh

--- a/controllers/charmedk8sconfig_controller_test.go
+++ b/controllers/charmedk8sconfig_controller_test.go
@@ -120,10 +120,18 @@ var _ = Describe("CharmedK8sConfig", func() {
 				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
-			// In a real cluster, the secret would be garbage collected because it has
-			// an OwnerReference to the CharmedK8sConfig. Garbage collection doesn't
-			// happen in this test environment. We have to clean it up manually.
-			Expect(k8sClient.Delete(ctx, secret)).Should(Succeed())
+			if useExistingCluster {
+				// This is a real cluster, so the secret should get garbage collected
+				Eventually(func() bool {
+					lookupKey := types.NamespacedName{Name: "test-charmedk8sconfig", Namespace: "default"}
+					err := k8sClient.Get(ctx, lookupKey, charmedK8sConfig)
+					return apierrors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue())
+			} else {
+				// Not a real cluster, so there is no garbage collection for orphaned
+				// secrets. Delete it.
+				Expect(k8sClient.Delete(ctx, secret)).Should(Succeed())
+			}
 			Expect(k8sClient.Delete(ctx, machine)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, cluster)).Should(Succeed())
 		},

--- a/controllers/charmedk8sconfig_controller_test.go
+++ b/controllers/charmedk8sconfig_controller_test.go
@@ -124,7 +124,7 @@ var _ = Describe("CharmedK8sConfig", func() {
 				// This is a real cluster, so the secret should get garbage collected
 				Eventually(func() bool {
 					lookupKey := types.NamespacedName{Name: "test-charmedk8sconfig", Namespace: "default"}
-					err := k8sClient.Get(ctx, lookupKey, charmedK8sConfig)
+					err := k8sClient.Get(ctx, lookupKey, secret)
 					return apierrors.IsNotFound(err)
 				}, timeout, interval).Should(BeTrue())
 			} else {

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+KUBECONFIG=/var/snap/microk8s/current/credentials/client.config
+REGISTRY="localhost:32000"
+IMG="$REGISTRY/capi-bootstrap-charmed-k8s-controller:latest"
+
+cd "$(dirname "$(realpath $0)")/../.."
+export KUBECONFIG="$KUBECONFIG"
+make docker-build docker-push deploy "IMG=$IMG" "DEPLOY_IMG=$IMG"
+kubectl rollout status -n capi-charmed-k8s-bootstrap-system deployment/capi-charmed-k8s-bootstrap-controller-manager --timeout 1m
+export USE_EXISTING_CLUSTER=true
+make test

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-KUBECONFIG=/var/snap/microk8s/current/credentials/client.config
 REGISTRY="localhost:32000"
 IMG="$REGISTRY/capi-bootstrap-charmed-k8s-controller:latest"
 
 cd "$(dirname "$(realpath $0)")/../.."
-export KUBECONFIG="$KUBECONFIG"
 make docker-build docker-push deploy "IMG=$IMG" "DEPLOY_IMG=$IMG"
 kubectl rollout status -n capi-charmed-k8s-bootstrap-system deployment/capi-charmed-k8s-bootstrap-controller-manager --timeout 1m
 export USE_EXISTING_CLUSTER=true

--- a/test/integration/setup-env.sh
+++ b/test/integration/setup-env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This script sets up an environment for running integration tests with a local
+# microk8s cluster.
+
+sudo apt-get update
+sudo apt-get install -y make gcc docker.io
+sudo snap install microk8s --classic
+sudo snap install go --channel 1.19/stable --classic
+sudo snap install kubectl --classic
+sudo microk8s enable registry
+sudo usermod -aG docker,microk8s ubuntu

--- a/test/integration/setup-env.sh
+++ b/test/integration/setup-env.sh
@@ -8,4 +8,5 @@ sudo snap install microk8s --classic
 sudo snap install go --channel 1.19/stable --classic
 sudo snap install kubectl --classic
 sudo microk8s enable registry
-sudo usermod -aG microk8s "$USER"
+mkdir -p "$HOME/.kube"
+sudo cat /var/snap/microk8s/current/credentials/client.config > "$HOME/.kube/config"

--- a/test/integration/setup-env.sh
+++ b/test/integration/setup-env.sh
@@ -8,4 +8,4 @@ sudo snap install microk8s --classic
 sudo snap install go --channel 1.19/stable --classic
 sudo snap install kubectl --classic
 sudo microk8s enable registry
-sudo usermod -aG microk8s ubuntu
+sudo usermod -aG microk8s "$USER"

--- a/test/integration/setup-env.sh
+++ b/test/integration/setup-env.sh
@@ -2,12 +2,10 @@
 set -euxo pipefail
 
 # This script sets up an environment for running integration tests with a local
-# microk8s cluster.
+# microk8s cluster. Assumes that make, gcc/clang, and docker are already installed
 
-sudo apt-get update
-sudo apt-get install -y make gcc docker.io
 sudo snap install microk8s --classic
 sudo snap install go --channel 1.19/stable --classic
 sudo snap install kubectl --classic
 sudo microk8s enable registry
-sudo usermod -aG docker,microk8s ubuntu
+sudo usermod -aG microk8s ubuntu


### PR DESCRIPTION
This PR adds integration tests that will set up a local MicroK8s cluster so that we can build the container image, deploy it into Kubernetes, and then test it in a real cluster with the real pod.

It turns out that by setting `USE_EXISTING_CLUSTER=true`, we can reuse the existing unit test suite against a real cluster. This is a feature of envtest as seen [here](https://github.com/kubernetes-sigs/controller-runtime/blob/53057ba616d1ba05ea6e295c1da870a555d9988d/pkg/envtest/server.go#L40), although I needed to make a few tweaks in our test suite to handle it. With these changes, I was able to throw away the pytest-based stuff I'd written before and keep our test code duplication to a minimum.

Leaving this in draft status until I get the GitHub actions passing.