### PR TITLE
Add metadata.yaml, make draft-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ DEPLOY_IMG ?= $(REGISTRY)$(IMG_PATH)$(IMG_NAME):$(IMG_TAG)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
+# Components file to be used by clusterctl
+COMPSFILE=bootstrap-components.yaml
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -102,6 +104,21 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
+
+.PHONY: components
+components: manifests kustomize ## Produce the components yaml
+	echo "---" > $(COMPSFILE)
+	$(KUSTOMIZE) build config/default/ >> $(COMPSFILE)
+
+.PHONY: draft-release
+draft-release: components ## Create a GitHub draft release
+ifndef RELEASE_TAG
+	$(error missing RELEASE_TAG)
+endif
+	gh release create "$(RELEASE_TAG)" metadata.yaml "$(COMPSFILE)" \
+		--target "$(shell git rev-parse --verify HEAD)" \
+		--generate-notes \
+		--draft
 
 ##@ Deployment
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,11 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 0
+  minor: 1
+  contract: v1beta1


### PR DESCRIPTION
Add bits to publish GitHub releases as provider repositories, per the [clusterctl provider contract](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html). When release time comes we should be able to run:

```
make draft-release RELEASE_TAG=v0.1.0
```

which will create a GitHub draft release that includes two assets: `metadata.yaml` and `bootstrap-components.yaml`. We can then review and publish the release, which will allow it to be used as a clusterctl provider repository.